### PR TITLE
fix npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "web-sprint-challenge-applied-javascript",
   "version": "1.0.0",
   "scripts": {
-    "start": "mkdir -p dist && cp -R ./assets ./dist && parcel index.html"
+    "start": "parcel index.html",
+    "postinstall": "mkdir -p dist && cp -R ./assets ./dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`npm start` script is causing issues for students after the initial run, since the dist folder already exists